### PR TITLE
Faculty account creation

### DIFF
--- a/frontend/src/components/InterestsTab.js
+++ b/frontend/src/components/InterestsTab.js
@@ -17,10 +17,11 @@ class InterestsTab extends Component {
 	}
 
 	render() {
+		var route = '/update-interests?user_type=' + this.props.user_type;
 		return (
 			<div>
 				<div className='tab-header'>
-					{this.props.tabTitle} <a href='/pick-your-interests'><i className="material-icons interest-editor">add</i></a>
+					{this.props.tabTitle} <a href={route} ><i className="material-icons interest-editor">add</i></a>
 				</div>
 				<div className='interests-tab'>
 					{this.state.interests.map((interest) => <div key={interest} className='floater-item'>{interest}</div>)}

--- a/frontend/src/components/InterestsTab.js
+++ b/frontend/src/components/InterestsTab.js
@@ -10,7 +10,7 @@ class InterestsTab extends Component {
 		return (
 			<div>
 				<div className='tab-header'>
-					INTERESTS <a href='/pick-your-interests'><i className="material-icons interest-editor">add</i></a>
+					{this.props.tabTitle} <a href='/pick-your-interests'><i className="material-icons interest-editor">add</i></a>
 				</div>
 				<div className='interests-tab'>
 					<div className='floater-item'>Computer Security</div>

--- a/frontend/src/components/LabSpecifications.css
+++ b/frontend/src/components/LabSpecifications.css
@@ -1,0 +1,59 @@
+.lab-specifications {
+	height: 100vh;
+}
+
+.lab-specifications-form {
+	background-color: #0277bd;
+	padding: 20px;
+}
+
+.lab-specifications-checklist {
+	padding-left: 30px;
+	padding-right: 30px;
+}
+
+.lab-specifications-text {
+	color: #eee;
+}
+
+.lab-specifications-input {
+	height: 150px;
+	background-color: #eee;
+	box-shadow: 1px 1px 5px;
+	color: #eee;
+	padding: 10px;
+	letter-spacing: 2px;
+	margin-bottom: 10px;
+	display: block;
+}
+
+.lab-specifications-input:hover {
+	color: #eee;
+}
+
+.columned-list {
+    -moz-column-count: 2;
+    -moz-column-gap: 30px;
+    -webkit-column-count: 2;
+    -webkit-column-gap: 30px;
+    column-count: 2;
+    column-gap: 30px;
+    text-align: left;
+}
+
+.lab-specifications-header {
+	font-size: 30px;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	background-color: rgb(41, 182, 246);
+	color: white;
+	margin-bottom: 20px;
+	margin-left: -20px;
+	margin-right: -20px;
+	margin-top: -20px;
+}
+
+.checkbox-white[type="checkbox"].filled-in:checked + label:after{
+     border: 2px solid #29B6F6;
+     background-color: #29B6F6;
+}

--- a/frontend/src/components/LabSpecifications.js
+++ b/frontend/src/components/LabSpecifications.js
@@ -1,0 +1,69 @@
+// Text gathering component for both lab-name and lab-description pages
+
+import React, {Component} from 'react';
+import SquareButton from './SquareButton';
+import './LabSpecifications.css';
+
+
+class LabSpecifications extends Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			specs: [
+				{
+					"id": "1",
+					"text": "Spots open?"
+				},
+				{
+					"id": "2",
+					"text": "Paying lab assistants?"
+				},
+				{
+					"id": "3",
+					"text": "Accepting undergraduate students?"
+				},
+				{
+					"id": "4",
+					"text": "May assistants use for credit?"
+				},
+				{
+					"id": "5",
+					"text": "Nobel prize prerequisite?"
+				},
+				{
+					"id": "6",
+					"text": "Payment available in bitcoin?"
+				},
+				{
+					"id": "7",
+					"text": "Placeholder"
+				},
+				{
+					"id": "7",
+					"text": "Placeholder"
+				},
+			]
+		};
+	}
+
+	render() {
+		return (
+			<div className='lab-specifications shift-down'>
+				<div className='container center-align lab-specifications-form shadow'>
+					<div className='lab-specifications-header'>Lab Specifications</div>
+					<form className='lab-specifications-checklist'>
+						<ul className = "columned-list">
+					    {this.state.specs.map((spec) => {
+							return (
+								<li><input type="checkbox" className="checkbox-white filled-in" id={spec.id}/>
+					      		<label className="lab-specifications-text" for={spec.id}>{spec.text}</label></li>);
+						})}
+						</ul>
+					</form>
+					<SquareButton destination='lab-website' label='next'/>
+				</div>
+			</div>
+		);
+	}
+}
+export default LabSpecifications;

--- a/frontend/src/components/LabSpecifications.js
+++ b/frontend/src/components/LabSpecifications.js
@@ -39,7 +39,7 @@ class LabSpecifications extends Component {
 					"text": "Placeholder"
 				},
 				{
-					"id": "7",
+					"id": "8",
 					"text": "Placeholder"
 				},
 			]

--- a/frontend/src/components/LabTextInfo.css
+++ b/frontend/src/components/LabTextInfo.css
@@ -1,0 +1,35 @@
+.lab-text-info {
+	height: 100vh;
+}
+
+.lab-text-info-form {
+	background-color: #0277bd;
+	padding: 20px;
+}
+
+.lab-text-info-input {
+	height: 150px;
+	background-color: #eee;
+	box-shadow: 1px 1px 5px;
+	color: #eee;
+	padding: 10px;
+	letter-spacing: 2px;
+	margin-bottom: 10px;
+	display: block;
+}
+
+.lab-text-info-input:hover {
+	color: #eee;
+}
+
+.lab-text-info-header {
+	font-size: 30px;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	background-color: rgb(41, 182, 246);
+	color: white;
+	margin-bottom: 20px;
+	margin-left: -20px;
+	margin-right: -20px;
+	margin-top: -20px;
+}

--- a/frontend/src/components/LabTextInfo.js
+++ b/frontend/src/components/LabTextInfo.js
@@ -1,0 +1,43 @@
+// Text gathering component for both lab-name and lab-description pages
+
+import React, {Component} from 'react';
+import SquareButton from './SquareButton';
+import './LabTextInfo.css';
+
+class LabTextInfo extends Component {
+	constructor(props) {
+		super(props);
+	}
+
+	render() {
+		var dest, header_text = '';
+		var url_arr = this.props.location.pathname.split('/');
+		if (url_arr[1] === 'lab-name') {
+			dest = 'lab-description';
+			header_text = 'Your Lab Name';
+		}
+		else if (url_arr[1] === 'lab-description') {
+			dest = 'pick-your-interests?user_type=faculty';
+			header_text = 'Lab Description';
+		}
+
+		return (
+			<div className='lab-text-info shift-down'>
+				<div className='container center-align lab-text-info-form shadow'>
+					<div className='lab-text-info-header'>{header_text}</div>
+					<form className='container'>
+						{url_arr[1] === 'lab-name' &&
+					        <input className='lab-text-info-input' placeholder='lab name'></input>
+					    }
+					    {url_arr[1] === 'lab-description' &&
+					       	<textArea className='lab-text-info-input' placeholder='lab description'></textArea>
+					    }
+						<SquareButton destination={dest} label='next'/>
+					</form>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default LabTextInfo;

--- a/frontend/src/components/LabWebsite.css
+++ b/frontend/src/components/LabWebsite.css
@@ -11,6 +11,7 @@
 	height: 150px;
 	background-color: #eee;
 	box-shadow: 1px 1px 5px;
+	border-bottom: 1px solid #eee;
 	color: #eee;
 	padding: 10px;
 	letter-spacing: 2px;
@@ -18,8 +19,28 @@
 	display: block;
 }
 
-.lab-website-input:hover {
+.input-field input[type=text]:focus + label,
+.input-field input[type=text]:hover + label,
+.input-field input[type=text]:active + label {
 	color: #eee;
+	border-bottom: 1px solid #eee;
+	box-shadow: 0 1px 0 0 #eee;
+}
+
+.input-field input[type=text]:focus,
+.input-field input[type=text]:hover,
+.input-field input[type=text]:active {
+	border-bottom: 1px solid #eee;
+	box-shadow: 0 1px 0 0 #eee;
+	color: #eee;
+}
+
+.lab-website-input:hover,
+.lab-website-input:active,
+.lab-website-input:focus {
+	color: #eee;
+	border-bottom: 1px solid #eee;
+	box-shadow: 0 1px 0 0 #eee;
 }
 
 .lab-website-header {

--- a/frontend/src/components/LabWebsite.css
+++ b/frontend/src/components/LabWebsite.css
@@ -19,24 +19,6 @@
 	display: block;
 }
 
-.input-field input[type=text]:focus + label,
-.input-field input[type=text]:hover + label,
-.input-field input[type=text]:active + label {
-	color: #eee;
-	border-bottom: 1px solid #eee;
-	box-shadow: 0 1px 0 0 #eee;
-}
-
-.input-field input[type=text]:focus,
-.input-field input[type=text]:hover,
-.input-field input[type=text]:active {
-	border-bottom: 1px solid #eee;
-	box-shadow: 0 1px 0 0 #eee;
-	color: #eee;
-}
-
-.lab-website-input:hover,
-.lab-website-input:active,
 .lab-website-input:focus {
 	color: #eee;
 	border-bottom: 1px solid #eee;

--- a/frontend/src/components/LabWebsite.js
+++ b/frontend/src/components/LabWebsite.js
@@ -12,8 +12,8 @@ class LabWebsite extends Component {
 			<div className='lab-website shift-down'>
 				<div className='container center-align lab-website-form shadow'>
 					<div className='lab-website-header'>Your Current Lab Website</div>
-					<form className='container'>
-						<input className='lab-website-input' placeholder="lab website URL"></input>
+					<form className='container input-field'>
+						<input className='lab-website-input' type="text" placeholder="lab website URL"></input>
 						<SquareButton destination='upload-image' label='next'/>
 					</form>
 				</div>

--- a/frontend/src/components/PickYourInterests.js
+++ b/frontend/src/components/PickYourInterests.js
@@ -118,28 +118,38 @@ class PickYourInterests extends Component {
 		var user_type = parse(this.props.location.search).user_type;
 		var url_arr = this.props.location.pathname.split('/');
 
-		if (url_arr[1] === "lab-skills") {
-			header_txt = "Necessary Lab Skills";
-			dest = 'lab-specifications';
-			placeholder_txt = "Skills used to work in your lab";
-		}
-		else {
-			if (user_type === "faculty") {
-				header_txt = "Your Lab Labels";
-				dest = 'lab-skills';
-				placeholder_txt = "descriptors for your lab work";
-			} 
-			else if (user_type === "student") {
-				header_txt = "Your Interests";
-				placeholder_txt = "field of interest";
-				dest = 'past-research';
-			}
-			else {
-				header_txt = "Your Interests";
-				placeholder_txt = "field of interest";
-				dest = 'student-profile';
-				btn_label = 'back';
-			}
+		switch(url_arr[1]) {
+			case "lab-skills":
+				header_txt = "Necessary Lab Skills";
+				dest = 'lab-specifications';
+				placeholder_txt = "Skills used to work in your lab";
+				break;
+			case "pick-your-interests":
+				switch(user_type) {
+					case "faculty":
+						header_txt = "Your Lab Labels";
+						placeholder_txt = "descriptors for your lab work";
+						dest = 'lab-skills';
+						break;
+					case "student":
+						header_txt = "Your Interests";
+						placeholder_txt = "field of interest";
+						dest = 'past-research';
+				}
+				break;
+			case "update-interests":
+				btn_label = "back";
+				switch(user_type) {
+					case "faculty":
+						header_txt = "Your Lab Labels";
+						placeholder_txt = "descriptors for your lab work";
+						dest = 'prof-page';
+						break;
+					case "student":
+						header_txt = "Your Interests";
+						placeholder_txt = "field of interest";
+						dest = 'student-profile';
+				}
 		}
 
 		let temporary = "default";

--- a/frontend/src/components/PickYourInterests.js
+++ b/frontend/src/components/PickYourInterests.js
@@ -1,13 +1,40 @@
 import React, {Component} from 'react';
 import { parse } from 'query-string';
-import SquareButton from './SquareButton'
-import Bubble from './Bubble'
-import './PickYourInterests.css'
+import SquareButton from './SquareButton';
+import Bubble from './Bubble';
+import './PickYourInterests.css';
+
 class PickYourInterests extends Component {
 	constructor(props) {
 		super(props);
+		var url_arr = this.props.location.pathname.split('/');
 		this.state = {
-			catalog: [
+			catalog: [],
+			interests: [],
+			filtered_catalog: [],
+			in_filter: false
+		};
+
+		if (url_arr[1] === 'lab-skills') {
+			var skills_catalog =  [
+				"plating",
+				"chromotography",
+				"MatLab",
+				"R",
+				"C++",
+				"Pen Testing",
+			];
+			var skills = [
+				"pun making",
+				"spectography",
+				"total phosphorus digestion",
+				"PCR",
+			];
+			this.state.catalog = skills_catalog;
+			this.state.interests = skills;
+		}
+		else {
+			var interests_catalog = [
 				"oncology",
 				"orange",
 				"orangutan",
@@ -18,24 +45,21 @@ class PickYourInterests extends Component {
 				"chemistry",
 				"physics",
 				"astro-physics",
-			],
-
-			interests: [
+			];
+			var interests = [
 				"security",
 				"fintech",
 				"machine learning",
 				"software development",
 				"biomedical devices",
-			],
-
-			filtered_catalog: [],
-			in_filter: false
-		};
-		this.filterList = this.filterList.bind(this);
+			];
+			this.state.catalog = interests_catalog;
+			this.state.interests = interests;
+		}
 	}
 
 	componentWillMount() {
-    	this.setState({filtered_catalog: this.state.catalog})
+    	this.setState({filtered_catalog: this.state.catalog});
   	}
 
 	filterList(event) {
@@ -90,17 +114,32 @@ class PickYourInterests extends Component {
 
 	render() {
 		var header_txt, placeholder_txt, dest = "";
+		var btn_label = 'next';
 		var user_type = parse(this.props.location.search).user_type;
+		var url_arr = this.props.location.pathname.split('/');
 
-		if (user_type === "faculty") {
-			header_txt = "Your Lab Labels";
-			dest = 'lab-website';
-			placeholder_txt = "descriptors for your lab work";
-		} 
-		else if (user_type === "student") {
-			header_txt = "Your Interests";
-			placeholder_txt = "field of interest";
-			dest = 'past-research';
+		if (url_arr[1] === "lab-skills") {
+			header_txt = "Necessary Lab Skills";
+			dest = 'lab-specifications';
+			placeholder_txt = "Skills used to work in your lab";
+		}
+		else {
+			if (user_type === "faculty") {
+				header_txt = "Your Lab Labels";
+				dest = 'lab-skills';
+				placeholder_txt = "descriptors for your lab work";
+			} 
+			else if (user_type === "student") {
+				header_txt = "Your Interests";
+				placeholder_txt = "field of interest";
+				dest = 'past-research';
+			}
+			else {
+				header_txt = "Your Interests";
+				placeholder_txt = "field of interest";
+				dest = 'student-profile';
+				btn_label = 'back';
+			}
 		}
 
 		let temporary = "default";
@@ -133,7 +172,7 @@ class PickYourInterests extends Component {
 						</div>
 					</div>
 				</div>
-				<SquareButton destination={dest} label='next'/>
+				<SquareButton destination={dest} label={btn_label}/>
 			</div>
 		);
 	}

--- a/frontend/src/components/PickYourInterests.js
+++ b/frontend/src/components/PickYourInterests.js
@@ -118,38 +118,42 @@ class PickYourInterests extends Component {
 		var user_type = parse(this.props.location.search).user_type;
 		var url_arr = this.props.location.pathname.split('/');
 
-		switch(url_arr[1]) {
-			case "lab-skills":
-				header_txt = "Necessary Lab Skills";
-				dest = 'lab-specifications';
-				placeholder_txt = "Skills used to work in your lab";
-				break;
-			case "pick-your-interests":
-				switch(user_type) {
-					case "faculty":
-						header_txt = "Your Lab Labels";
-						placeholder_txt = "descriptors for your lab work";
-						dest = 'lab-skills';
-						break;
-					case "student":
-						header_txt = "Your Interests";
-						placeholder_txt = "field of interest";
-						dest = 'past-research';
-				}
-				break;
-			case "update-interests":
-				btn_label = "back";
-				switch(user_type) {
-					case "faculty":
-						header_txt = "Your Lab Labels";
-						placeholder_txt = "descriptors for your lab work";
-						dest = 'prof-page';
-						break;
-					case "student":
-						header_txt = "Your Interests";
-						placeholder_txt = "field of interest";
-						dest = 'student-profile';
-				}
+		if (url_arr[1] === 'lab-skills') {
+			header_txt = "Necessary Lab Skills";
+			dest = 'lab-specifications';
+			placeholder_txt = "Skills used to work in your lab";
+		}
+		else {
+			if (user_type === "faculty") {
+				header_txt = "Your Lab Labels";
+				placeholder_txt = "descriptors for your lab work";
+			}
+			else (user_type === "student") {
+				header_txt = "Your Interests";
+				placeholder_txt = "field of interest";
+			}
+
+			switch(url_arr[1]) {
+				case "pick-your-interests":
+					switch(user_type) {
+						case "faculty":
+							dest = 'lab-skills';
+							break;
+						case "student":
+							dest = 'past-research';
+					}
+					break;
+				case "update-interests":
+					btn_label = "back";
+					switch(user_type) {
+						case "faculty":
+							dest = 'prof-page';
+							break;
+						case "student":
+							dest = 'student-profile';
+					}
+			}
+	
 		}
 
 		let temporary = "default";

--- a/frontend/src/components/ProfPage.js
+++ b/frontend/src/components/ProfPage.js
@@ -33,7 +33,7 @@ class ProfPage extends Component {
 					<BioTab header='what we do' msg={this.state.lab_summary}/>
 				</div>
 				<div className='row flex'>
-					<div className='profile-tab shadow'><InterestsTab /></div>
+					<div className='profile-tab shadow'><InterestsTab tabTitle="LABELS" /></div>
 					<div className='profile-tab shadow'><SkillsTab /></div>
 				</div>
 				{/*<div className='left-align row flex'>

--- a/frontend/src/components/ProfPage.js
+++ b/frontend/src/components/ProfPage.js
@@ -34,7 +34,7 @@ class ProfPage extends Component {
 					<BioTab header='what we do' msg={this.state.lab_summary}/>
 				</div>
 				<div className='row flex'>
-					<div className='profile-tab shadow'><InterestsTab tabTitle="LABELS" /></div>
+					<div className='profile-tab shadow'><InterestsTab tabTitle="LABELS" user_type="faculty" /></div>
 					<div className='profile-tab shadow'><SkillsTab /></div>
 				</div>
 				{/*<div className='left-align row flex'>

--- a/frontend/src/components/SignUp.js
+++ b/frontend/src/components/SignUp.js
@@ -1,6 +1,22 @@
 import React, {Component} from 'react';
 import './SignUp.css';
 class SignUp extends Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			route: '/pick-your-interests?user_type=student'
+		};
+	}
+
+	handleUserTypeCheck(event) {
+		if (event.target.value === 'faculty') {
+			this.setState({route: '/lab-name'});
+		}
+		else {
+			this.setState({route: '/pick-your-interests?user_type=student'});
+		}
+	}
+
 	render() {
 		return (
 				<div id="form" className="center-align container">
@@ -8,7 +24,7 @@ class SignUp extends Component {
 				      <div className="container">
 				        <div className="form-header center-align grey-text text-darken-3">Join Perch</div>
 				        <div className="row">
-				          <form className="col s12" action='/pick-your-interests'>
+				          <form className="col s12" action={this.state.route}>
 				            <div className="row min-margin">
 				              <div className="input-field col s6">
 				                <input id="first_name" type="text" className="validate grey-text text-darken-2" required />
@@ -38,9 +54,9 @@ class SignUp extends Component {
 				                <label htmlFor="password_retype">Re-type Password</label>
 				              </div>
 				            </div>
-				              <input className="radio" name="user_type" type="radio" id="faculty" value="faculty" required />
+				              <input className="radio" name="user_type" type="radio" id="faculty" value="faculty" onChange={this.handleUserTypeCheck.bind(this)} required />
 				              <label htmlFor="faculty">Faculty</label>
-				              <input className="radio" name="user_type" type="radio" id="student" value="student" required />
+				              <input className="radio" name="user_type" type="radio" id="student" value="student" onChange={this.handleUserTypeCheck.bind(this)} required />
 				              <label htmlFor="student">Student</label>
 				            <div className="submit-container row min-margin center-align">
 				              <button className="btn waves-effect waves-light submit-btn"  type="submit" name="action">De-awkwardize

--- a/frontend/src/components/StudentProfile.js
+++ b/frontend/src/components/StudentProfile.js
@@ -38,7 +38,7 @@ class StudentProfile extends Component {
 					{/*<div  style={{fontSize: '40px', color: 'white', letterSpacing: '2px'}}>Benji Bear</div>*/}
 				</div>
 				<div className='row flex'>
-					<div className='profile-tab shadow' style={{width: '50%'}}><InterestsTab /></div>
+					<div className='profile-tab shadow' style={{width: '50%'}}><InterestsTab tabTitle="INTERESTS" /></div>
 					<div className='profile-tab shadow' style={{width: '50%'}}><SkillsTab /></div>
 				</div>
 				<div className='row flex'>

--- a/frontend/src/components/StudentProfile.js
+++ b/frontend/src/components/StudentProfile.js
@@ -38,7 +38,7 @@ class StudentProfile extends Component {
 					{/*<div  style={{fontSize: '40px', color: 'white', letterSpacing: '2px'}}>Benji Bear</div>*/}
 				</div>
 				<div className='row flex'>
-					<div className='profile-tab shadow' style={{width: '50%'}}><InterestsTab tabTitle="INTERESTS" /></div>
+					<div className='profile-tab shadow' style={{width: '50%'}}><InterestsTab tabTitle="INTERESTS" user_type="student" /></div>
 					<div className='profile-tab shadow' style={{width: '50%'}}><SkillsTab /></div>
 				</div>
 				<div className='row flex'>

--- a/frontend/src/components/UploadImage.js
+++ b/frontend/src/components/UploadImage.js
@@ -16,10 +16,10 @@ class UploadImage extends Component {
 						<form className='file-field input-field'>
 							<div className="btn upload-image-btn">
 							  <span>File</span>
-							  <input type="file" multiple />
+							  <input type="file" />
 							</div>
 							<div className="file-path-wrapper">
-							  <input className="file-path validate" type="text" placeholder="Upload one or more files" />
+							  <input className="file-path validate" type="text" placeholder="Upload file" />
 							</div>
 						</form>
 						<SquareButton destination='prof-page' label='next'/>

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -35,7 +35,7 @@ class Router extends Component {
 							<Route path='/student-profile' component={ StudentProfile } />
 							<Route path='/lab-match' component={ LabMatch }/>
 							<Route path='/pick-your-interests' component={ PickYourInterests }/>
-							<Route path='/pick-your-interests' component={ PickYourInterests }/>
+							<Route path='/update-interests' component={ PickYourInterests }/>
 							<Route path='/lab-skills' component={ PickYourInterests }/>
 							<Route path='/lab-website' component={ LabWebsite }/>
 							<Route path='/upload-image' component={ UploadImage }/>

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -11,6 +11,8 @@ import LabMatch from './components/LabMatch';
 import PickYourInterests from './components/PickYourInterests';
 import LabWebsite from './components/LabWebsite';
 import UploadImage from './components/UploadImage';
+import LabTextInfo from './components/LabTextInfo';
+import LabSpecifications from './components/LabSpecifications';
 import PastResearch from './components/PastResearch';
 import NotableClasses from './components/NotableClasses';
 import ProfPage from './components/ProfPage';
@@ -33,8 +35,13 @@ class Router extends Component {
 							<Route path='/student-profile' component={ StudentProfile } />
 							<Route path='/lab-match' component={ LabMatch }/>
 							<Route path='/pick-your-interests' component={ PickYourInterests }/>
+							<Route path='/pick-your-interests' component={ PickYourInterests }/>
+							<Route path='/lab-skills' component={ PickYourInterests }/>
 							<Route path='/lab-website' component={ LabWebsite }/>
 							<Route path='/upload-image' component={ UploadImage }/>
+							<Route path='/lab-name' component= { LabTextInfo }/>
+							<Route path='/lab-description' component= { LabTextInfo }/>
+							<Route path='/lab-specifications' component= { LabSpecifications }/>
 							<Route path='/past-research' component={ PastResearch }/>
 							<Route path='/notable-classes' component={ NotableClasses }/>
 							<Route path='/prof-page' component={ ProfPage }/>


### PR DESCRIPTION
Added in:
- Lab title page  (LabTextInfo component)
- Lab description page (LabTextInfo component)
- Lab Skills Page*
- Lab Specifications Page (checklist)
- Functional routing for clicking the '+' for interests/labels

(*) So, I also added the 'skills' to PickYourInterests, so it serves for choosing faculty skills, (then probably also student skills), faculty/student interests/labels, and updating faculty/student interests/labels. But then if we also want to add functionality to update faculty/student skills, that'd be another few on top. TBH I'm not sure if it's too gross or not, but if y'all think it's okay for it all to be together, can we switch it's name to something more general so it can fit choosing interests/labels/skills? Like BubbleChoice or something.
